### PR TITLE
Fix protocol sink blocking issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ build/%.py: grc/%.grc
 	@sed -i 's/'\
 	'dest=\"no_api\", type=\"intx\", default=0/'\
 	'dest=\"no_api\", action=\"store_true\", default=False/g' $@
+	@sed -i 's/'\
+	'dest=\"no_blocks\", type=\"intx\", default=0/'\
+	'dest=\"no_blocks\", action=\"store_true\", default=False/g' $@
 	@chmod u+x $@
 	python -m compileall $@
 	f=$@ && x=$${f%.py} && y="$${x//_/-}" &&\

--- a/grc/blocksat_rx.grc
+++ b/grc/blocksat_rx.grc
@@ -1813,7 +1813,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1472, 308)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>
@@ -2370,6 +2413,10 @@
     <param>
       <key>disable_api</key>
       <value>bool(no_api)</value>
+    </param>
+    <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
     </param>
     <param>
       <key>_coordinate</key>

--- a/grc/blocksat_rx_gui.grc
+++ b/grc/blocksat_rx_gui.grc
@@ -1956,7 +1956,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1488, 308)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>
@@ -2658,6 +2701,10 @@
     <param>
       <key>disable_api</key>
       <value>bool(no_api)</value>
+    </param>
+    <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
     </param>
     <param>
       <key>_coordinate</key>

--- a/grc/blocksat_rx_upper.grc
+++ b/grc/blocksat_rx_upper.grc
@@ -1201,6 +1201,10 @@
       <value>bool(no_api)</value>
     </param>
     <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
+    </param>
+    <param>
       <key>_coordinate</key>
       <value>(1176, 460)</value>
     </param>
@@ -1425,7 +1429,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(992, 308)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>

--- a/grc/blocksat_rx_upper_gui.grc
+++ b/grc/blocksat_rx_upper_gui.grc
@@ -1330,6 +1330,10 @@
       <value>bool(no_api)</value>
     </param>
     <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
+    </param>
+    <param>
       <key>_coordinate</key>
       <value>(1200, 460)</value>
     </param>
@@ -2627,7 +2631,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(992, 308)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>

--- a/grc/blocksat_rx_usrp.grc
+++ b/grc/blocksat_rx_usrp.grc
@@ -1941,7 +1941,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1696, 408)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>
@@ -2545,6 +2588,10 @@
     <param>
       <key>disable_api</key>
       <value>bool(no_api)</value>
+    </param>
+    <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
     </param>
     <param>
       <key>_coordinate</key>

--- a/grc/blocksat_rx_usrp_gui.grc
+++ b/grc/blocksat_rx_usrp_gui.grc
@@ -2084,7 +2084,50 @@
     </param>
     <param>
       <key>label</key>
-      <value>Disable User API Data Output</value>
+      <value>True to Disable Satellite API Data Output</value>
+    </param>
+    <param>
+      <key>short_id</key>
+      <value></value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>intx</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>parameter</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1696, 512)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>no_blocks</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>True to Disable Bitcoin FIBRE Data Output</value>
     </param>
     <param>
       <key>short_id</key>
@@ -2833,6 +2876,10 @@
     <param>
       <key>disable_api</key>
       <value>bool(no_api)</value>
+    </param>
+    <param>
+      <key>disable_blocks</key>
+      <value>bool(no_blocks)</value>
     </param>
     <param>
       <key>_coordinate</key>


### PR DESCRIPTION
- Add parameter that allows disabling reception and the corresponding output of
  blocks data into the Bitcoin FIBRE named pipe.

- Update all instances of the Protocol Sink block from the gr-blocksat library
  and connect the value of the referred parameter (that disables blocks output)
  to the "disable_blocks" option of the sink blocks.

- Update Makefile to make the "--no-blocks" command-line argument a boolean,
  just like the previous "--no-api" argument.

- Update the submodule pointer to the latest gr-blocksat commit, which includes
  the associated changes to the Protocol Sink block.

Fixes #26