### PR TITLE
Fixed broken link

### DIFF
--- a/doc/bitcoin.md
+++ b/doc/bitcoin.md
@@ -74,7 +74,7 @@ bitcoind
 ```
 
 Note that other [Bitcoin Core
-options](https://wiki.bitcoin.com/w/Running_Bitcoin) are supported and can be
+options](https://en.bitcoinwiki.org/wiki/Running_Bitcoind) are supported and can be
 added to the generated `bitcoin.conf` file as needed, or directly as arguments
 to the above command. For example, you can run the node based on satellite links
 only (unplugged from the internet) using option `connect=0` on `bitcoin.conf` or


### PR DESCRIPTION
Link to "Bitcoin Core Options" on bitcoin.com wiki was broken, substituted with equivalent page on bitcoinwiki.org listing bitcoind parameters