### PR TITLE
Added instructions regarding SAT>IP firmware

### DIFF
--- a/doc/sat-ip.md
+++ b/doc/sat-ip.md
@@ -65,6 +65,13 @@ blocksat-cli sat-ip
 > blocks this traffic type, you can specify the Sat-IP server's IP address
 > (i.e., the Satellite Base Station address) directly using option `-a/--addr`.
 
+> Note: If the command above fails with a 'connection reset by peer' error,
+> changes are you need to perform a firmware update on the Sat-IP server.
+> Visit `http://<Sat-IP server's IP address>:8000`. If you *don't* see a
+> login form, and are presented with a very minimal white page listing only
+> FW version and HW version, visit the [manufacturer's site](http://www.selfsat.com/download-1) 
+> to obtain the latest firmware & instructions.
+
 ## Next Steps
 
 At this point, if your antenna is already correctly pointed, you should be able


### PR DESCRIPTION
While setting up my Base Station, I noticed that `blocksat-cli sat-ip -a <IP>` was failing due to a rejected HTTP request. Upon further investigation, I noticed that my SAT>IP 22 had firmware version 2.2.19, which did not feature a login page. Upon upgrading the firmware to 3.1.18 from the manufacturer's website ([Selfsat](http://www.selfsat.com/download-1)}, my SAT>IP 22 now featured a login page & `blocksat-cli sat-ip -a <IP>` now worked as intended.

Details of my encounter (in Japanese) including some screenshots can be found in this [blog post](https://spotlight.soy/detail?article_id=590td8ctp).