### PR TITLE
Add options to verify, upgrade, and work around the Sat-IP firmware version

### DIFF
--- a/blocksatcli/dependencies.py
+++ b/blocksatcli/dependencies.py
@@ -4,7 +4,7 @@ from . import config, defs, util
 import sys, os, subprocess, logging, glob, json
 from shutil import which
 from pprint import pformat
-import platform, distro, requests
+import platform, distro
 from distutils.version import LooseVersion
 logger = logging.getLogger(__name__)
 
@@ -15,26 +15,6 @@ target_map = {
     "standalone": defs.standalone_setup_type,
     "sat-ip": defs.sat_ip_setup_type
 }
-
-def _download_file(url, destdir, dry_run):
-    filename   = url.split('/')[-1]
-    local_path = os.path.join(destdir, url.split('/')[-1])
-
-    if (dry_run):
-        print("Download: {}".format(url))
-        print("Save at: {}".format(destdir))
-        return
-
-    logger.debug("Download {} and save at {}".format(filename, destdir))
-    with requests.get(url, stream=True) as r:
-        r.raise_for_status()
-        with open(local_path, 'wb') as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                # If you have chunk encoded response uncomment if
-                # and set chunk_size parameter to None.
-                #if chunk:
-                f.write(chunk)
-    return local_path
 
 
 def _check_distro(supported_distros, setup_type):
@@ -505,7 +485,7 @@ def drivers(args):
     tbs_linux_url = "https://www.tbsdtv.com/download/document/linux/"
     fw_tarball    = "tbs-tuner-firmwares_v1.0.tar.bz2"
     fw_url        = tbs_linux_url + fw_tarball
-    _download_file(fw_url, driver_src_dir, args.dry_run)
+    util.download_file(fw_url, driver_src_dir, args.dry_run, logger=logger)
 
     # Install the firmware
     runner.run(util.root_cmd(["tar", "jxvf", fw_tarball, "-C",

--- a/blocksatcli/dependencies.py
+++ b/blocksatcli/dependencies.py
@@ -238,9 +238,9 @@ def _install_specific(target, interactive=True, update=False, dry=False):
             'yum': ["iproute", "iptables"]
         },
         'sat-ip': {
-            'apt': ["tsduck"],
-            'dnf': ["tsduck"],
-            'yum': ["tsduck"]
+            'apt': ["iproute2", "tsduck"],
+            'dnf': ["iproute", "tsduck"],
+            'yum': ["iproute", "tsduck"]
         }
     }
     # NOTE:

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -456,8 +456,13 @@ class SatIp():
         # is unknown, filter only by the DVB-S2 parameters.
         candidate_frontends = []
         for fe in active_frontends:
-            if float(fe['fq']) != self.params['freq'] or \
-               fe['pol'] != self.params['pol']:
+            try:
+                fe_freq = float(fe['fq'])
+                fe_pol = fe['pol']
+            except ValueError:
+                continue
+
+            if fe_freq != self.params['freq'] or fe_pol != self.params['pol']:
                 continue
 
             if self.local_addr is None or fe['ip'] == self.local_addr:

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -121,6 +121,34 @@ class SatIp():
         else:
             self._set_from_ssdp_dev(sat_ip_devices[0])
 
+    def check_reachable(self):
+        """Check if the Sat-IP server is reachable
+
+        The server address could be specified directly instead of
+        auto-discovered. Hence, it is worth double-checking the server can be
+        reached by this client.
+
+        Returns:
+            Boolean indicating whether the Sat-IP server is reachable.
+
+        """
+        self._assert_addr()
+
+        try:
+            r = requests.get(self.base_url)
+            r.raise_for_status()
+        except requests.exceptions.ConnectionError as errc:
+            logger.error("Connection Error: {}".format(errc))
+            return False
+        except requests.exceptions.HTTPError as errh:
+            logger.error("HTTP Error: {}".format(errh))
+            return False
+        except requests.exceptions.RequestException as err:
+            logger.error("Error: {}".format(err))
+            return False
+
+        return True
+
     def check_fw_version(self, min_version="3.1.18"):
         """Check if the Sat-IP server has the minimum required firmware version
 
@@ -514,6 +542,10 @@ def launch(args):
             logger.error(e)
             sys.exit(1)
         sat_ip.set_addr(addr)
+
+    # Check the Sat-IP server is reachable
+    if not sat_ip.check_reachable():
+        return
 
     # Check if the Sat-IP device has the minimum required firmware version
     min_fw_version = "3.1.18" if args.fe_monitoring else "2.2.19"

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -452,7 +452,7 @@ class SatIp():
 
         active_frontends = []
         for fe in info['frontends']:
-            if fe['frontend']['ip'] != 'none':
+            if fe['frontend']['ip'] != 'none' and fe['frontend']['ip'] != 'NA':
                 active_frontends.append(fe['frontend'])
 
         if len(active_frontends) == 0:

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -387,8 +387,9 @@ def _get_monitor(args):
         sat_name  : Satellite name
 
     """
-    # Force scrolling logs if tsp is configured to print to stdout
-    scrolling = tsp.prints_to_stdout(args) or args.log_scrolling
+    # Force scrolling logs if tsp is configured to print to stdout or if
+    # operating in debug mode
+    scrolling = tsp.prints_to_stdout(args) or args.debug or args.log_scrolling
 
     return monitoring.Monitor(args.cfg_dir,
                               logfile=args.log_file,
@@ -409,6 +410,8 @@ def _monitoring_thread(sat_ip, handler):
         status = sat_ip.fe_stats()
 
         if (status is None):
+            if (not handler.scroll):
+                print()
             logger.warning("Failed to fetch the frontend status.")
             continue
 

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -505,6 +505,12 @@ def subparser(subparsers):
                    "(DVB-S2 demodulator and tuner). Use this option when the "
                    "server does not provide a login page or to avoid "
                    "authentication conflicts between concurrent clients.")
+    p.add_argument(
+        '--ignore-http-errors',
+        default=False,
+        action='store_true',
+        help="Immediately retry the connection if an HTTP error occurs while "
+        "reading the MPEG transport stream from the Sat-IP server")
     tsp.add_to_parser(p)
     monitoring.add_to_parser(p)
     p.set_defaults(func=launch)
@@ -586,9 +592,12 @@ def launch(args):
     url = "http://" + sat_ip.host + "/?" + urlencode(params)
 
     # Run tsp
+    input_plugin = ['-I', 'http', url, '--infinite']
+    if (args.ignore_http_errors):
+        input_plugin.append('--ignore-errors')
+
     tsp_handler = tsp.Tsp()
-    if (not tsp_handler.gen_cmd(args,
-                                in_plugin=['-I', 'http', url, '--infinite'])):
+    if (not tsp_handler.gen_cmd(args, in_plugin=input_plugin)):
         return
     logger.debug("Run:")
     logger.debug(" ".join(tsp_handler.cmd))

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -108,7 +108,16 @@ class SatIp():
             logger.warning("Failed to read the local Sat-IP client address")
             logger.warning(e)
             return
-        local_addr = res.splitlines()[0].split()[4].decode()
+
+        out_line = res.decode().splitlines()[0].split()
+        if (out_line[1] == "via" and len(out_line) > 6):
+            local_addr = out_line[6]
+        elif (len(out_line) > 4):
+            local_addr = out_line[4]
+        else:
+            logger.warning("Failed to read the local Sat-IP client address")
+            return
+
         try:
             ip_address(local_addr)
         except ValueError as e:
@@ -586,7 +595,7 @@ def launch(args):
         logger.info("Run \"blocksat-cli cfg\" to re-configure your setup")
         sys.exit(1)
 
-    if (not dependencies.check_apps(['tsp'])):
+    if (not dependencies.check_apps(['tsp', 'ip'])):
         return
 
     # Discover or define the IP address to communicate with the Sat-IP server

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -349,7 +349,17 @@ class SatIp():
         r.raise_for_status()
 
     def fe_stats(self):
-        """Read DVB-S2 frontend stats"""
+        """Read DVB-S2 frontend stats
+
+        Returns:
+
+            (dict): Dictionary with the frontend status in case the reading is
+            successful. None on the following error conditions: 1) if the
+            Sat-IP server does not return any frontend info; 2) if the frontend
+            serving this client is not active in the Sat-IP server; and 3) if
+            the frontend status parsing fails.
+
+        """
         self._assert_addr()
         url = self.base_url + "/cgi-bin/index.cgi"
         rv = self.session.get(url, params={'cmd': 'frontend_info'})
@@ -378,7 +388,10 @@ class SatIp():
 
         for fe in active_frontends:
             if fe['ip'] == self.local_addr:
-                return self._parse_fe_info(fe)
+                try:
+                    return self._parse_fe_info(fe)
+                except ValueError:
+                    pass  # let this function return None in the end
 
 
 def _parse_modcod(modcod):

--- a/blocksatcli/satip.py
+++ b/blocksatcli/satip.py
@@ -477,11 +477,14 @@ class SatIp():
             if self.local_addr is None or fe['ip'] == self.local_addr:
                 candidate_frontends.append(fe)
 
-        if len(candidate_frontends) > 1:
+        n_candidate = len(candidate_frontends)
+        if n_candidate > 1:
             logger.warning(
                 "The status logs can be unreliable when streaming from "
                 "multiple RF frontends concurrently (found {} frontends)".
-                format(len(candidate_frontends)))
+                format(n_candidate))
+        elif n_candidate == 0:
+            return None
 
         try:
             return self._parse_fe_info(candidate_frontends[0])

--- a/blocksatcli/test_satip.py
+++ b/blocksatcli/test_satip.py
@@ -78,13 +78,13 @@ class TestApi(TestCase):
         # Old firmware version that does not satisfy the minimum
         mock_get.return_value = MockResponse("2.2.19")
         sat_ip = satip.SatIp()
-        sat_ip.set_addr("192.168.100.2")
+        sat_ip.set_server_addr("192.168.100.2")
         self.assertFalse(sat_ip.check_fw_version())
 
         # Recent firmware version satisfying the minimum
         mock_get.return_value = MockResponse("3.1.18")
         sat_ip = satip.SatIp()
-        sat_ip.set_addr("192.168.100.2")
+        sat_ip.set_server_addr("192.168.100.2")
         self.assertTrue(sat_ip.check_fw_version())
 
     @patch('requests.post')
@@ -101,7 +101,7 @@ class TestApi(TestCase):
                 }
             })
         sat_ip = satip.SatIp()
-        sat_ip.set_addr("192.168.100.2")
+        sat_ip.set_server_addr("192.168.100.2")
         fw_upgrade_ok = sat_ip.upgrade_fw("/tmp/",
                                           interactive=False,
                                           no_wait=True)


### PR DESCRIPTION
- When starting the Sat-IP client, check if the Sat-IP server is running the latest firmware version (3.1.18).
- If the Sat-IP server is running with outdated firmware, prompt the user to accept a firmware upgrade and execute the upgrade upon the user's acceptance.
- Add option to disable the DVB-S2 frontend monitoring such that the Sat-IP client can run as-is (with no need for upgrade) when the Sat-IP server is running with an old firmware version.